### PR TITLE
Switch DOCX to PDF conversion from docx2pdf to Pandoc

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,3 +5,9 @@ services:
     buildCommand: pip install -r requirements.txt
     startCommand: gunicorn app:app
     plan: free
+    nativeEnvironment:
+      packages:
+        - pandoc
+        - texlive-latex-base
+        - texlive-fonts-recommended
+        - wkhtmltopdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pdf2docx
 PyPDF2
 python-docx
 gunicorn
-docx2pdf


### PR DESCRIPTION
- Modified render.yaml to install Pandoc, texlive-latex-base, texlive-fonts-recommended, and wkhtmltopdf system dependencies.
- Removed docx2pdf from requirements.txt.
- Updated app.py to use subprocess to call Pandoc for DOCX to PDF conversion, including error handling and logging.